### PR TITLE
Fix HTTPS connection

### DIFF
--- a/fritzswitch.py
+++ b/fritzswitch.py
@@ -20,6 +20,8 @@
 
 import argparse
 import hashlib
+import os
+import ssl
 from urllib.request import urlopen
 from xml.etree.ElementTree import parse
 
@@ -147,6 +149,9 @@ if __name__ == "__main__":
         host = 'http://' + host
     if host.endswith('/'):
         host = host[0:-1]
+    
+    if getattr(ssl, '_create_unverified_context', None):
+        ssl._create_default_https_context = ssl._create_unverified_context
     
     fha = FritzHomeAuto(args.user, args.password, host)
     

--- a/fritzswitch.py
+++ b/fritzswitch.py
@@ -143,7 +143,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     
     host = args.host
-    if not (host.startswith('http://') and host.startswith('https://')):
+    if not (host.startswith('http://') or host.startswith('https://')):
         host = 'http://' + host
     if host.endswith('/'):
         host = host[0:-1]


### PR DESCRIPTION
The https:// prefix was not correctly recognized, so that an additional http:// prefix was added.
Moreover, the SSL certificate check has to be disabled to allow for self-signed certificates of most fritz.boxes.